### PR TITLE
Upgrade to reusable-workflows v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,13 +2,12 @@ name: ci
 
 # Controls when the workflow will run
 on:
-
   # Trigger the workflow on all pushes, except on tag creation
   push:
     branches:
-    - '**'
+      - '**'
     tags-ignore:
-    - '**'
+      - '**'
 
   # Trigger the workflow on all pull requests
   pull_request: ~
@@ -17,11 +16,10 @@ on:
   workflow_dispatch: ~
 
 jobs:
-
   # Calls a reusable CI NodeJS workflow to qa & test the current repository.
   #   It will install dependencies and run lint and test commands.
   ci:
     name: ci
-    uses: ecmwf-actions/reusable-workflows/.github/workflows/ci-node.yml@v1
+    uses: ecmwf-actions/reusable-workflows/.github/workflows/ci-node.yml@v2
     with:
       self_build: false

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # sync-repository
 
 [![Changelog](https://img.shields.io/github/package-json/v/ecmwf-actions/sync-repository)](CHANGELOG.md)
-[![Build Status](https://img.shields.io/github/workflow/status/ecmwf-actions/sync-repository/ci)](https://github.com/ecmwf-actions/sync-repository/actions/workflows/ci.yml)
+[![Build Status](https://img.shields.io/github/actions/workflow/status/ecmwf-actions/sync-repository/ci.yml?branch=main)](https://github.com/ecmwf-actions/sync-repository/actions/workflows/ci.yml)
 [![Licence](https://img.shields.io/github/license/ecmwf-actions/sync-repository)](https://github.com/ecmwf-actions/sync-repository/blob/main/LICENSE)
 
 A Github action to sync a Git repository.


### PR DESCRIPTION
Upgrade to `reusable-workflows` v2 since v1 uses platforms which were dropped by github actions (macos 10 and ubuntu 18).
Fix build status badge in README.